### PR TITLE
Use Goredis universal client to accommodate cluster clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zerodha/fastcache/v2
+module github.com/zerodha/fastcache/v3
 
 go 1.12
 

--- a/stores/goredis/redis.go
+++ b/stores/goredis/redis.go
@@ -34,13 +34,13 @@ const (
 // Store is a Redis cache store implementation for fastcache.
 type Store struct {
 	prefix string
-	cn     *redis.Client
+	cn     redis.UniversalClient
 	ctx    context.Context
 }
 
 // New creates a new Redis instance. prefix is the prefix to apply to all
 // cache keys.
-func New(prefix string, client *redis.Client) *Store {
+func New(prefix string, client redis.UniversalClient) *Store {
 	return &Store{
 		prefix: prefix,
 		cn:     client,

--- a/stores/goredis/redis.go
+++ b/stores/goredis/redis.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/zerodha/fastcache/v2"
+	"github.com/zerodha/fastcache/v3"
 )
 
 const (

--- a/stores/goredis/redis_test.go
+++ b/stores/goredis/redis_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alicebob/miniredis"
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
-	"github.com/zerodha/fastcache/v2"
+	"github.com/zerodha/fastcache/v3"
 )
 
 func newTestRedis(t *testing.T) *redis.Client {

--- a/stores/redis/redis.go
+++ b/stores/redis/redis.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/zerodha/fastcache/v2"
+	"github.com/zerodha/fastcache/v3"
 )
 
 const (


### PR DESCRIPTION
- Accept `redis.UniversalClient` interface instead of `*redis.Client` instance to accommodate other types of Redis clients like clustered and r/w load-balanced.
- Since its a breaking change the module path have been upgraded to v3