### PR TITLE
Refactor internal content struct to use strings instead of []bytes.

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.13", "1.14", "1.15", "1.16"]
+        go: ["1.16", "1.20"]
 
     runs-on: ubuntu-20.04
 

--- a/fastcache.go
+++ b/fastcache.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -52,8 +53,8 @@ type Options struct {
 // Item represents the cache entry for a single endpoint with the actual cache
 // body and metadata.
 type Item struct {
-	ContentType []byte
-	ETag        []byte
+	ContentType string
+	ETag        string
 	Blob        []byte
 }
 
@@ -113,9 +114,9 @@ func (f *FastCache) Cached(h fastglue.FastRequestHandler, o *Options, group stri
 		// with the stored one (if there's any).
 		if o.ETag {
 			var (
-				match = r.RequestCtx.Request.Header.Peek("If-None-Match")
+				match = string(r.RequestCtx.Request.Header.Peek("If-None-Match"))
 			)
-			if len(match) > 4 && len(blob.ETag) > 0 && bytes.Contains(match, blob.ETag) {
+			if len(match) > 4 && len(blob.ETag) > 0 && strings.Contains(match, blob.ETag) {
 				r.RequestCtx.SetStatusCode(fasthttp.StatusNotModified)
 				return nil
 			}
@@ -127,7 +128,7 @@ func (f *FastCache) Cached(h fastglue.FastRequestHandler, o *Options, group stri
 				r.RequestCtx.Response.Header.Add("ETag", `"`+string(blob.ETag)+`"`)
 			}
 			r.RequestCtx.SetStatusCode(fasthttp.StatusOK)
-			r.RequestCtx.SetContentTypeBytes(blob.ContentType)
+			r.RequestCtx.SetContentType(blob.ContentType)
 			if _, err := r.RequestCtx.Write(blob.Blob); err != nil && o.Logger != nil {
 				o.Logger.Printf("error writing request: %v", err)
 			}
@@ -196,13 +197,13 @@ func (f *FastCache) DelGroup(namespace string, group ...string) error {
 // cache caches a response body.
 func (f *FastCache) cache(r *fastglue.Request, namespace, group string, o *Options) error {
 	// ETag?.
-	var etag []byte
+	var etag string
 	if o.ETag {
 		e, err := generateRandomString(16)
 		if err != nil {
 			return fmt.Errorf("error generating etag: %v", err)
 		}
-		etag = e
+		etag = string(e)
 	}
 
 	// Write cache to the store (etag, content type, response body).
@@ -222,7 +223,7 @@ func (f *FastCache) cache(r *fastglue.Request, namespace, group string, o *Optio
 
 	err := f.s.Put(namespace, group, uri, Item{
 		ETag:        etag,
-		ContentType: r.RequestCtx.Response.Header.ContentType(),
+		ContentType: string(r.RequestCtx.Response.Header.ContentType()),
 		Blob:        blob,
 	}, o.TTL)
 	if err != nil && o.Logger != nil {

--- a/fastcache.go
+++ b/fastcache.go
@@ -203,7 +203,7 @@ func (f *FastCache) cache(r *fastglue.Request, namespace, group string, o *Optio
 		if err != nil {
 			return fmt.Errorf("error generating etag: %v", err)
 		}
-		etag = string(e)
+		etag = e
 	}
 
 	// Write cache to the store (etag, content type, response body).
@@ -239,17 +239,17 @@ func (f *FastCache) cache(r *fastglue.Request, namespace, group string, o *Optio
 
 // generateRandomString generates a cryptographically random,
 // alphanumeric string of length n.
-func generateRandomString(totalLen int) ([]byte, error) {
+func generateRandomString(totalLen int) (string, error) {
 	const dictionary = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	var (
 		bytes = make([]byte, totalLen)
 	)
 	if _, err := rand.Read(bytes); err != nil {
-		return nil, err
+		return "", err
 	}
 
 	for k, v := range bytes {
 		bytes[k] = dictionary[v%byte(len(dictionary))]
 	}
-	return bytes, nil
+	return string(bytes), nil
 }

--- a/fastcache_test.go
+++ b/fastcache_test.go
@@ -1,7 +1,7 @@
 package fastcache_test
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -111,7 +111,7 @@ func getReq(url, etag string, t *testing.T) (*http.Response, string) {
 		t.Fatal(err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(b)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zerodha/fastcache/v3
 
-go 1.12
+go 1.16
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect

--- a/stores/goredis/redis_test.go
+++ b/stores/goredis/redis_test.go
@@ -34,8 +34,8 @@ func TestNew(t *testing.T) {
 	testGroup := "group"
 	testEndpoint := "/test/endpoint"
 	testItem := fastcache.Item{
-		ETag:        []byte("etag"),
-		ContentType: []byte("content_type"),
+		ETag:        "etag",
+		ContentType: "content_type",
 		Blob:        []byte("{}"),
 	}
 

--- a/stores/redis/redis.go
+++ b/stores/redis/redis.go
@@ -2,14 +2,16 @@
 // The internal structure looks like this where
 // XX1234 = namespace, marketwach = group
 // ```
-// CACHE:XX1234:marketwatch {
-//     "/user/marketwatch_ctype" -> []byte
-//     "/user/marketwatch_etag" -> []byte
-//     "/user/marketwatch_blob" -> []byte
-//     "/user/marketwatch/123_ctype" -> []byte
-//     "/user/marketwatch/123_etag" -> []byte
-//     "/user/marketwatch/123_blob" -> []byte
-// }
+//
+//	CACHE:XX1234:marketwatch {
+//	    "/user/marketwatch_ctype" -> []byte
+//	    "/user/marketwatch_etag" -> []byte
+//	    "/user/marketwatch_blob" -> []byte
+//	    "/user/marketwatch/123_ctype" -> []byte
+//	    "/user/marketwatch/123_etag" -> []byte
+//	    "/user/marketwatch/123_blob" -> []byte
+//	}
+//
 // ```
 package redis
 
@@ -57,8 +59,8 @@ func (s *Store) Get(namespace, group, uri string) (fastcache.Item, error) {
 	}
 
 	out = fastcache.Item{
-		ContentType: resp[0],
-		ETag:        resp[1],
+		ContentType: string(resp[0]),
+		ETag:        string(resp[1]),
 		Blob:        resp[2],
 	}
 	return out, err


### PR DESCRIPTION
`Item.Etag`, `Item.ContentType` are fields that store tiny strings, but they were defined as []bytes leading to awkward and unnecessary string/byte conversions. In addition, in the goredis implementation, the arbitrarily long blob was being converted from `string` to `[]byte`, causing large allocations.

This PR simplifies this and switches small fields to `string`.