### PR TITLE
fix: prevent buffer reuse in async mode for Put method

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -77,7 +77,9 @@ type Item struct {
 	ContentType string
 	Compression string
 	ETag        string
-	Blob        []byte
+	// If the Blob is used beyond the scope of the request, it should be copied.
+	// Such as when the cache is written asynchronously.
+	Blob []byte
 }
 
 // Store represents a backend data store where bytes are cached. Individual


### PR DESCRIPTION
If the mode is async, we need to copy request Blob to prevent fasthttp from reusing the buffer since we are going to use the buffer in a separate goroutine beyond the scope of the current request.