### PR TITLE
feat(goredis): optimize DelGroup to use single Redis DEL command

### DIFF
--- a/stores/goredis/redis.go
+++ b/stores/goredis/redis.go
@@ -278,15 +278,16 @@ func (s *Store) Del(namespace, group, uri string) error {
 
 // DelGroup deletes a whole group.
 func (s *Store) DelGroup(namespace string, groups ...string) error {
-	p := s.cn.Pipeline()
-	for _, group := range groups {
-		if err := p.Del(s.ctx, s.key(namespace, group)).Err(); err != nil {
-			return err
-		}
+	if len(groups) == 0 {
+		return nil
 	}
 
-	_, err := p.Exec(s.ctx)
-	return err
+	keys := make([]string, len(groups))
+	for i, group := range groups {
+		keys[i] = s.key(namespace, group)
+	}
+
+	return s.cn.Del(s.ctx, keys...).Err()
 }
 
 func (s *Store) key(namespace, group string) string {


### PR DESCRIPTION
## Summary
- Optimize `DelGroup` method in `stores/goredis/redis.go` to use single Redis DEL command
- Instead of sending multiple individual DEL commands in a pipeline, collect all keys and send a single DEL command with multiple keys
- Reduces network overhead and improves performance for bulk deletions

## Test plan
- Verify `DelGroup` method works correctly with single group
- Verify `DelGroup` method works correctly with multiple groups
- Verify empty groups case returns nil error
- Verify Redis DEL command receives all keys in single call

Fixes #18